### PR TITLE
Big Screen: Un-round corners inside .GameWidget & make rows of games look even

### DIFF
--- a/styles/big-screen-blaseball.user.css
+++ b/styles/big-screen-blaseball.user.css
@@ -19,6 +19,13 @@
         min-width: 300px;
         padding: 2px;
         margin-bottom: 0;
+
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+    }
+    .GameWidget > :nth-last-child(2) {
+        flex-grow: 1;
     }
     .GameWidget > *:first-child {
         border-bottom-left-radius: 0;
@@ -93,5 +100,17 @@
         padding-left: 20px;
         padding-right: 20px;
     }
-}
 
+    /* Styles that only apply to the wider layout. */
+    @media(min-width: 1081px) {
+        .GameWidget > :nth-last-child(2) {
+            flex-grow: 0;
+        }
+        .GameWidget > :last-child {
+            flex-grow: 1;
+        }
+        .GameWidget-Upcoming-BetButtons {
+            margin-bottom: 10px;
+        }
+    }
+}

--- a/styles/big-screen-blaseball.user.css
+++ b/styles/big-screen-blaseball.user.css
@@ -20,6 +20,17 @@
         padding: 2px;
         margin-bottom: 0;
     }
+    .GameWidget > *:first-child {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+    .GameWidget > *:not(:first-child):not(:last-child) {
+        border-radius: 0;
+    }
+    .GameWidget > *:last-child {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
+    }
     .GameWidget-Full-Live,
     .GameWidget-Full-Upcoming {
         display: block;

--- a/styles/big-screen-blaseball.user.css
+++ b/styles/big-screen-blaseball.user.css
@@ -19,24 +19,6 @@
         min-width: 300px;
         padding: 2px;
         margin-bottom: 0;
-
-        display: flex;
-        flex-direction: column;
-        gap: 0;
-    }
-    .GameWidget > :nth-last-child(2) {
-        flex-grow: 1;
-    }
-    .GameWidget > *:first-child {
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-    }
-    .GameWidget > *:not(:first-child):not(:last-child) {
-        border-radius: 0;
-    }
-    .GameWidget > *:last-child {
-        border-top-left-radius: 0;
-        border-top-right-radius: 0;
     }
     .GameWidget-Full-Live,
     .GameWidget-Full-Upcoming {
@@ -100,17 +82,5 @@
         padding-left: 20px;
         padding-right: 20px;
     }
-
-    /* Styles that only apply to the wider layout. */
-    @media(min-width: 1081px) {
-        .GameWidget > :nth-last-child(2) {
-            flex-grow: 0;
-        }
-        .GameWidget > :last-child {
-            flex-grow: 1;
-        }
-        .GameWidget-Upcoming-BetButtons {
-            margin-bottom: 10px;
-        }
-    }
 }
+

--- a/styles/testing/big-screen-blaseball.user.css
+++ b/styles/testing/big-screen-blaseball.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
-@name        BIG SCREEN Blaseball (TEST VER)
+@name        BIG SCREEN Blaseball [No longer includes Emoji Fix]
 @namespace   holmesmr.github
-@version     0.0.16-pre1
+@version     0.0.17-pre
 @author       cepheus (https://github.com/holmesmr)
 @homepageURL  http://holmesmr.github.io/Blaseball-Userstyles/
 @license     Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) 
@@ -19,6 +19,23 @@
         min-width: 300px;
         padding: 2px;
         margin-bottom: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0;
+    }
+    .GameWidget > :nth-last-child(2) {
+        flex-grow: 1;
+    }
+    .GameWidget > *:first-child {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+    .GameWidget > *:not(:first-child):not(:last-child) {
+        border-radius: 0;
+    }
+    .GameWidget > *:last-child {
+        border-top-left-radius: 0;
+        border-top-right-radius: 0;
     }
     .GameWidget-Full-Live,
     .GameWidget-Full-Upcoming {
@@ -82,5 +99,17 @@
         padding-left: 20px;
         padding-right: 20px;
     }
-}
 
+    /* Styles that only apply to the wider layout. */
+    @media(min-width: 1081px) {
+        .GameWidget > :nth-last-child(2) {
+            flex-grow: 0;
+        }
+        .GameWidget > :last-child {
+            flex-grow: 1;
+        }
+        .GameWidget-Upcoming-BetButtons {
+            margin-bottom: 10px;
+        }
+    }
+}

--- a/styles/testing/big-screen-blaseball.user.css
+++ b/styles/testing/big-screen-blaseball.user.css
@@ -1,5 +1,5 @@
 /* ==UserStyle==
-@name        BIG SCREEN Blaseball [No longer includes Emoji Fix]
+@name        BIG SCREEN Blaseball (TEST VER)
 @namespace   holmesmr.github
 @version     0.0.17-pre
 @author       cepheus (https://github.com/holmesmr)


### PR DESCRIPTION
Removes the rounded corners from the middle div's inside .GameWidget and ensures rows of .GameWidgets don't look uneven.

![image](https://user-images.githubusercontent.com/4542458/109614326-f5cb4580-7ade-11eb-8f6a-28b2288500f4.png)

Apologies for the 2nd commit, this was change enough to be 2 PR's but I don't do this often and forgot how it worked.