### PR TITLE
Fix to the feed detail colour

### DIFF
--- a/styles/testing/win10-emoji-fix.user.css
+++ b/styles/testing/win10-emoji-fix.user.css
@@ -31,10 +31,10 @@
     .Events-List-Row.Events-List-Minor > div {
         font-family: "Lora", "Courier New", monospace, serif;
     }
-    .theme-light .Events-List-Row.Events-List-Minor > div {
+    .theme-light .Events-List-Row.Events-List-Minor > span {
         color: #000000;
     }
-    .theme-dark .Events-List-Row.Events-List-Minor > div {
+    .theme-dark .Events-List-Row.Events-List-Minor > span {
         color: #ffffff;
     }
 }


### PR DESCRIPTION
The HTML for the events feed detail is using spans rather than divs, making the events unreadable on dark mode with this extension - I've switched the selector out to use spans as well to resolve this

Before:
![image](https://user-images.githubusercontent.com/5725774/110110196-648df480-7da6-11eb-95f7-c85127d9d52b.png)
After:
![image](https://user-images.githubusercontent.com/5725774/110110259-766f9780-7da6-11eb-9f41-df17ab53ce85.png)