### PR TITLE
Various fixes for Emoji Fix test build

### DIFF
--- a/styles/testing/win10-emoji-fix.user.css
+++ b/styles/testing/win10-emoji-fix.user.css
@@ -37,4 +37,8 @@
     .theme-dark .Events-List-Row.Events-List-Minor > span {
         color: #ffffff;
     }
+    /* Tarot Fix */
+	.Recap-Blessing-Team {
+		color: white;
+	}
 }

--- a/styles/testing/win10-emoji-fix.user.css
+++ b/styles/testing/win10-emoji-fix.user.css
@@ -37,11 +37,18 @@
     .theme-dark .Events-List-Row.Events-List-Minor > span {
         color: #ffffff;
     }
+	/* Tarot Fix */
 	.Recap-Blessing-Team {
 		color: white;
-	}
+	} 
+	/* Player Line Name Fix */
     .Widget-PlayerLineName {
 		font-family: "Open Sans", "Helvetica Neue", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 		color: white;
-    }
+    }	
+	/* Minor Events Feed Fix */
+	.Events-List-Row-Group {
+		color: white;
+	}
+
 }

--- a/styles/testing/win10-emoji-fix.user.css
+++ b/styles/testing/win10-emoji-fix.user.css
@@ -37,18 +37,18 @@
     .theme-dark .Events-List-Row.Events-List-Minor > span {
         color: #ffffff;
     }
-	/* Tarot Fix */
-	.Recap-Blessing-Team {
-		color: white;
-	} 
-	/* Player Line Name Fix */
+    /* Tarot Fix */
+    .Recap-Blessing-Team {
+        color: white;
+    } 
+    /* Player Line Name Fix */
     .Widget-PlayerLineName {
-		font-family: "Open Sans", "Helvetica Neue", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
-		color: white;
-    }	
-	/* Minor Events Feed Fix */
-	.Events-List-Row-Group {
-		color: white;
-	}
+        font-family: "Open Sans", "Helvetica Neue", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+        color: white;
+    }    
+    /* Minor Events Feed Fix */
+    .Events-List-Row-Group {
+        color: white;
+    }
 
 }

--- a/styles/testing/win10-emoji-fix.user.css
+++ b/styles/testing/win10-emoji-fix.user.css
@@ -37,8 +37,11 @@
     .theme-dark .Events-List-Row.Events-List-Minor > span {
         color: #ffffff;
     }
-    /* Tarot Fix */
 	.Recap-Blessing-Team {
 		color: white;
 	}
+    .Widget-PlayerLineName {
+		font-family: "Open Sans", "Helvetica Neue", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+		color: white;
+    }
 }


### PR DESCRIPTION
1. Correctly styles the emoji in the recap section of the tarot reading page. 

Before:
![before](https://user-images.githubusercontent.com/3696731/110526707-bfdc2180-80db-11eb-9ace-4319e8088277.PNG)

After:
![after](https://user-images.githubusercontent.com/3696731/110526719-c1a5e500-80db-11eb-939f-8131139c899c.PNG)

2. Fixes the PlayerLineName color/styling that was changed when the styling on the event list was moved from div to span. (this incorporates content from bufar's pull request)

Before:
![PlayerLineName-Before](https://user-images.githubusercontent.com/3696731/110533410-958e6200-80e3-11eb-8297-64938021bd2e.PNG)

After:
![PlayerLineName-After](https://user-images.githubusercontent.com/3696731/110533422-99ba7f80-80e3-11eb-8561-db0799631300.PNG)

3. Fixes text color on the feed when changes occur.

Before:
![minor-before](https://user-images.githubusercontent.com/3696731/110545349-97135680-80f2-11eb-8204-dfd5dca3adcb.PNG)

After:
![minor-after](https://user-images.githubusercontent.com/3696731/110545366-9d093780-80f2-11eb-9c5b-c4bf2fd0a5b0.PNG)

